### PR TITLE
Bump Python Layer version to 95, Node Layer version to 112, and Extension Layer version to 58

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ module "example_lambda_function" {
   }
 
   datadog_extension_layer_version = 57
-  datadog_python_layer_version = 94
+  datadog_python_layer_version = 95
 }
 ```
 
@@ -56,7 +56,7 @@ module "example_lambda_function" {
   }
 
   datadog_extension_layer_version = 57
-  datadog_node_layer_version = 109
+  datadog_node_layer_version = 112
 }
 ```
 
@@ -159,8 +159,8 @@ No modules.
 | <a name="input_architectures"></a> [architectures](#input\_architectures) | Instruction set architecture for your Lambda function. Valid values are ["x86\_64"] and ["arm64"]. | `list(string)` | <pre>["x86_64"]</pre> | no |
 | <a name="input_code_signing_config_arn"></a> [code\_signing\_config\_arn](#input\_code\_signing\_config\_arn) | To enable code signing for this function, specify the ARN of a code-signing configuration. A code-signing configuration includes a set of signing profiles, which define the trusted publishers for this function. | `string` | `null` | no |
 | <a name="input_datadog_extension_layer_version"></a> [datadog\_extension\_layer\_version](#input\_datadog\_extension\_layer\_version) | Version for the Datadog Extension Layer | `number` | `57` | no |
-| <a name="input_datadog_node_layer_version"></a> [datadog\_node\_layer\_version](#input\_datadog\_node\_layer\_version) | Version for the Datadog Node Layer | `number` | `109` | no |
-| <a name="input_datadog_python_layer_version"></a> [datadog\_python\_layer\_version](#input\_datadog\_python\_layer\_version) | Version for the Datadog Python Layer | `number` | `94` | no |
+| <a name="input_datadog_node_layer_version"></a> [datadog\_node\_layer\_version](#input\_datadog\_node\_layer\_version) | Version for the Datadog Node Layer | `number` | `112` | no |
+| <a name="input_datadog_python_layer_version"></a> [datadog\_python\_layer\_version](#input\_datadog\_python\_layer\_version) | Version for the Datadog Python Layer | `number` | `95` | no |
 | <a name="input_dead_letter_config_target_arn"></a> [dead\_letter\_config\_target\_arn](#input\_dead\_letter\_config\_target\_arn) | ARN of an SNS topic or SQS queue to notify when an invocation fails. | `string` | `null` | no |
 | <a name="input_description"></a> [description](#input\_description) | Description of what your Lambda Function does. | `string` | `null` | no |
 | <a name="input_environment_variables"></a> [environment\_variables](#input\_environment\_variables) | Map of environment variables that are accessible from the function code during execution. | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ module "example_lambda_function" {
     "DD_VERSION" : "1.0.0"
   }
 
-  datadog_extension_layer_version = 57
+  datadog_extension_layer_version = 58
   datadog_python_layer_version = 95
 }
 ```
@@ -55,7 +55,7 @@ module "example_lambda_function" {
     "DD_VERSION" : "1.0.0"
   }
 
-  datadog_extension_layer_version = 57
+  datadog_extension_layer_version = 58
   datadog_node_layer_version = 112
 }
 ```
@@ -158,7 +158,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_architectures"></a> [architectures](#input\_architectures) | Instruction set architecture for your Lambda function. Valid values are ["x86\_64"] and ["arm64"]. | `list(string)` | <pre>["x86_64"]</pre> | no |
 | <a name="input_code_signing_config_arn"></a> [code\_signing\_config\_arn](#input\_code\_signing\_config\_arn) | To enable code signing for this function, specify the ARN of a code-signing configuration. A code-signing configuration includes a set of signing profiles, which define the trusted publishers for this function. | `string` | `null` | no |
-| <a name="input_datadog_extension_layer_version"></a> [datadog\_extension\_layer\_version](#input\_datadog\_extension\_layer\_version) | Version for the Datadog Extension Layer | `number` | `57` | no |
+| <a name="input_datadog_extension_layer_version"></a> [datadog\_extension\_layer\_version](#input\_datadog\_extension\_layer\_version) | Version for the Datadog Extension Layer | `number` | `58` | no |
 | <a name="input_datadog_node_layer_version"></a> [datadog\_node\_layer\_version](#input\_datadog\_node\_layer\_version) | Version for the Datadog Node Layer | `number` | `112` | no |
 | <a name="input_datadog_python_layer_version"></a> [datadog\_python\_layer\_version](#input\_datadog\_python\_layer\_version) | Version for the Datadog Python Layer | `number` | `95` | no |
 | <a name="input_dead_letter_config_target_arn"></a> [dead\_letter\_config\_target\_arn](#input\_dead\_letter\_config\_target\_arn) | ARN of an SNS topic or SQS queue to notify when an invocation fails. | `string` | `null` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@
 variable "datadog_extension_layer_version" {
   description = "Version for the Datadog Extension Layer"
   type        = number
-  default     = 57
+  default     = 58
 }
 
 variable "datadog_node_layer_version" {

--- a/variables.tf
+++ b/variables.tf
@@ -11,13 +11,13 @@ variable "datadog_extension_layer_version" {
 variable "datadog_node_layer_version" {
   description = "Version for the Datadog Node Layer"
   type        = number
-  default     = 109
+  default     = 112
 }
 
 variable "datadog_python_layer_version" {
   description = "Version for the Datadog Python Layer"
   type        = number
-  default     = 94
+  default     = 95
 }
 
 


### PR DESCRIPTION
### What does this PR do?

Bumps Datadog Python Layer version to 95, Datadog Node Layer version to 112, and Datadog Extension Layer version to 58.

### Motivation

Make latest enhancements and bug fixes in Datadog layers available.

### Additional Notes

### Describe how to test/QA your changes

Follow the instructions using one of the examples to deploy a Lambda function instrumented with Datadog to AWS.