### PR TITLE
Document Lack of Container Image Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,6 @@ No modules.
 | <a name="input_image_config_command"></a> [image\_config\_command](#input\_image\_config\_command) | Parameters that you want to pass in with entry\_point. | `list(string)` | `null` | no |
 | <a name="input_image_config_entry_point"></a> [image\_config\_entry\_point](#input\_image\_config\_entry\_point) | Entry point to your application, which is typically the location of the runtime executable. | `list(string)` | `null` | no |
 | <a name="input_image_config_working_directory"></a> [image\_config\_working\_directory](#input\_image\_config\_working\_directory) | Working directory. | `string` | `null` | no |
-| <a name="input_image_uri"></a> [image\_uri](#input\_image\_uri) | ECR image URI containing the function's deployment package. | `string` | `null` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | Amazon Resource Name (ARN) of the AWS Key Management Service (KMS) key that is used to encrypt environment variables. | `string` | `null` | no |
 | <a name="input_layers"></a> [layers](#input\_layers) | List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function. | `list(string)` | `[]` | no |
 | <a name="input_logging_config_application_log_level"></a> [logging\_config\_application\_log\_level](#input\_logging\_config\_application\_log\_level) | For JSON structured logs, choose the detail level of the logs your application sends to CloudWatch when using supported logging libraries. | `string` | `null` | no |
@@ -215,7 +214,6 @@ No modules.
 | <a name="output_function_name"></a> [function\_name](#output\_function\_name) | Unique name for your Lambda Function |
 | <a name="output_handler"></a> [handler](#output\_handler) | Function entrypoint in your code. |
 | <a name="output_image_config"></a> [image\_config](#output\_image\_config) | Container image configuration values that override the values in the container image Dockerfile. |
-| <a name="output_image_uri"></a> [image\_uri](#output\_image\_uri) | ECR image URI containing the function's deployment package. |
 | <a name="output_invoke_arn"></a> [invoke\_arn](#output\_invoke\_arn) | ARN to be used for invoking Lambda Function from API Gateway. |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | Amazon Resource Name (ARN) of the AWS Key Management Service (KMS) key that is used to encrypt environment variables. |
 | <a name="output_last_modified"></a> [last\_modified](#output\_last\_modified) | Date this resource was last modified. |

--- a/README.md
+++ b/README.md
@@ -170,9 +170,6 @@ No modules.
 | <a name="input_filename"></a> [filename](#input\_filename) | Path to the function's deployment package within the local filesystem. | `string` | `null` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | Unique name for your Lambda Function. | `string` | `null` | no |
 | <a name="input_handler"></a> [handler](#input\_handler) | Function entrypoint in your code. | `string` | `null` | no |
-| <a name="input_image_config_command"></a> [image\_config\_command](#input\_image\_config\_command) | Parameters that you want to pass in with entry\_point. | `list(string)` | `null` | no |
-| <a name="input_image_config_entry_point"></a> [image\_config\_entry\_point](#input\_image\_config\_entry\_point) | Entry point to your application, which is typically the location of the runtime executable. | `list(string)` | `null` | no |
-| <a name="input_image_config_working_directory"></a> [image\_config\_working\_directory](#input\_image\_config\_working\_directory) | Working directory. | `string` | `null` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | Amazon Resource Name (ARN) of the AWS Key Management Service (KMS) key that is used to encrypt environment variables. | `string` | `null` | no |
 | <a name="input_layers"></a> [layers](#input\_layers) | List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function. | `list(string)` | `[]` | no |
 | <a name="input_logging_config_application_log_level"></a> [logging\_config\_application\_log\_level](#input\_logging\_config\_application\_log\_level) | For JSON structured logs, choose the detail level of the logs your application sends to CloudWatch when using supported logging libraries. | `string` | `null` | no |
@@ -213,7 +210,6 @@ No modules.
 | <a name="output_filename"></a> [filename](#output\_filename) | Path to the function's deployment package within the local filesystem. |
 | <a name="output_function_name"></a> [function\_name](#output\_function\_name) | Unique name for your Lambda Function |
 | <a name="output_handler"></a> [handler](#output\_handler) | Function entrypoint in your code. |
-| <a name="output_image_config"></a> [image\_config](#output\_image\_config) | Container image configuration values that override the values in the container image Dockerfile. |
 | <a name="output_invoke_arn"></a> [invoke\_arn](#output\_invoke\_arn) | ARN to be used for invoking Lambda Function from API Gateway. |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | Amazon Resource Name (ARN) of the AWS Key Management Service (KMS) key that is used to encrypt environment variables. |
 | <a name="output_last_modified"></a> [last\_modified](#output\_last\_modified) | Date this resource was last modified. |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ module "example_lambda_function" {
 
 ### Lambda Function
 
-All of the arguments available in the [aws_lambda_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) resource are available in this Terraform module.
+Arguments available in the [aws_lambda_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) resource are available in this Terraform module. Lambda functions created from container images are not supported by this module.
 
 Arguments defined as blocks in the `aws_lambda_function` resource are redefined as variables with their nested arguments.
 

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ check "runtime_support" {
 
 check "container_image_support" {
   assert {
-    condition     = var.package_type == "Image"
+    condition     = var.package_type != "Image"
     error_message = "Container images are not supported by the lambda-datadog Terraform module"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -139,17 +139,6 @@ resource "aws_lambda_function" "this" {
   filename      = var.filename
   function_name = var.function_name
   handler       = local.handler
-
-  dynamic "image_config" {
-    for_each = var.image_config_command != null || var.image_config_entry_point != null || var.image_config_working_directory != null ? [true] : []
-
-    content {
-      command           = var.image_config_command
-      entry_point       = var.image_config_entry_point
-      working_directory = var.image_config_working_directory
-    }
-  }
-
   kms_key_arn = var.kms_key_arn
 
   # Datadog layers are defined in single element lists

--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,14 @@ check "runtime_support" {
         "python3.12",
       ],
     var.runtime)
-    error_message = "${var.runtime} Lambda runtime is not supported by the Datadog Terraform module for AWS Lambda"
+    error_message = "${var.runtime} Lambda runtime is not supported by the lambda-datadog Terraform module"
+  }
+}
+
+check "container_image_support" {
+  assert {
+    condition     = var.package_type == "Image"
+    error_message = "Container images are not supported by the lambda-datadog Terraform module"
   }
 }
 
@@ -143,7 +150,6 @@ resource "aws_lambda_function" "this" {
     }
   }
 
-  image_uri   = var.image_uri
   kms_key_arn = var.kms_key_arn
 
   # Datadog layers are defined in single element lists

--- a/outputs.tf
+++ b/outputs.tf
@@ -58,11 +58,6 @@ output "image_config" {
   value       = aws_lambda_function.this.image_config
 }
 
-output "image_uri" {
-  description = "ECR image URI containing the function's deployment package."
-  value       = aws_lambda_function.this.image_uri
-}
-
 output "invoke_arn" {
   description = "ARN to be used for invoking Lambda Function from API Gateway."
   value       = aws_lambda_function.this.invoke_arn

--- a/outputs.tf
+++ b/outputs.tf
@@ -53,11 +53,6 @@ output "handler" {
   value       = aws_lambda_function.this.handler
 }
 
-output "image_config" {
-  description = "Container image configuration values that override the values in the container image Dockerfile."
-  value       = aws_lambda_function.this.image_config
-}
-
 output "invoke_arn" {
   description = "ARN to be used for invoking Lambda Function from API Gateway."
   value       = aws_lambda_function.this.invoke_arn

--- a/variables.tf
+++ b/variables.tf
@@ -109,12 +109,6 @@ variable "image_config_working_directory" {
   default     = null
 }
 
-variable "image_uri" {
-  description = "ECR image URI containing the function's deployment package."
-  type        = string
-  default     = null
-}
-
 variable "kms_key_arn" {
   description = "Amazon Resource Name (ARN) of the AWS Key Management Service (KMS) key that is used to encrypt environment variables."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -91,24 +91,6 @@ variable "handler" {
   default     = null
 }
 
-variable "image_config_command" {
-  description = "Parameters that you want to pass in with entry_point."
-  type        = list(string)
-  default     = null
-}
-
-variable "image_config_entry_point" {
-  description = "Entry point to your application, which is typically the location of the runtime executable."
-  type        = list(string)
-  default     = null
-}
-
-variable "image_config_working_directory" {
-  description = "Working directory."
-  type        = string
-  default     = null
-}
-
 variable "kms_key_arn" {
   description = "Amazon Resource Name (ARN) of the AWS Key Management Service (KMS) key that is used to encrypt environment variables."
   type        = string


### PR DESCRIPTION
### What does this PR do?

- Removes variables and outputs related to container images
- Adds a check that warns about lack of support for container images
- Updates documentation to reflect the lack of support for container images

### Motivation

https://github.com/DataDog/terraform-aws-lambda-datadog/issues/2

### Additional Notes

### Describe how to test/QA your changes

Follow the instructions using one of the examples to deploy a Lambda function instrumented with Datadog to AWS.