### PR TITLE
Update Readme for Consistency with Datadog Public Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,22 @@ This Terraform module wraps the [aws_lambda_function](https://registry.terraform
 
 ### Python
 ```
-module "example_lambda_function" {
-  source = "Datadog/lambda-datadog/aws"
+module "lambda-datadog" {
+  source  = "DataDog/lambda-datadog/aws"
+  version = "1.0.0"
 
   filename      = "example.zip"
   function_name = "example-function"
   role          = aws_iam_role.lambda_role.arn
   handler       = "app.lambda_handler"
   runtime       = "python3.11"
-  memory_size = 256
+  memory_size   = 256
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "arn:aws:secretsmanager:us-east-1:000000000000:secret:example-secret"
     "DD_ENV" : "dev"
     "DD_SERVICE" : "example-service"
+    "DD_SITE": "datadoghq.com"
     "DD_VERSION" : "1.0.0"
   }
 
@@ -38,20 +40,22 @@ module "example_lambda_function" {
 
 ### Node
 ```
-module "example_lambda_function" {
-  source = "Datadog/lambda-datadog/aws"
+module "lambda-datadog" {
+  source  = "DataDog/lambda-datadog/aws"
+  version = "1.0.0"
 
   filename      = "example.zip"
   function_name = "example-function"
   role          = aws_iam_role.lambda_role.arn
   handler       = "index.lambda_handler"
   runtime       = "nodejs20.x"
-  memory_size = 256
+  memory_size   = 256
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "arn:aws:secretsmanager:us-east-1:000000000000:secret:example-secret"
     "DD_ENV" : "dev"
     "DD_SERVICE" : "example-service"
+    "DD_SITE": "datadoghq.com"
     "DD_VERSION" : "1.0.0"
   }
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Use the following variables to select the versions of the Datadog Lambda layers 
 | `datadog_node_layer_version` | Version of the [Datadog Node Lambda layer](https://github.com/DataDog/datadog-lambda-js/releases) to install |
 | `datadog_python_layer_version` | Version of the [Datadog Python Lambda layer](https://github.com/DataDog/datadog-lambda-python/releases) to install |
 
+#### Selecting the Datadog Site
+
+The default Datadog site is `datadoghq.com`. To use a different site set the `DD_SITE` environment variable to the desired destination site. See [Getting Started with Datadog Sites](https://docs.datadoghq.com/getting_started/site/) for the available site values.
+
 #### Configuration
 
 Use Environment variables to configure Datadog Serverless Monitoring. Refer to the documentation below for environment variables available in the Serverless Agent (packaged in the Extension layer) and in the Tracing libraries (packaged in the runtime layers).

--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -9,6 +9,7 @@ A simple Node Lambda function with out of the box Datadog instrumentation.
 * Create a `terraform.tfvars` file
   - Set the `datadog_secret_arn` to the arn of the secret you just created
   - Set the `datadog_service_name` to the name of the service you want to use to filter for the resource in Datadog
+  - Set the `datadog_site` to the [Datadog destination site](https://docs.datadoghq.com/getting_started/site/) for your metrics, traces, and logs
 * Run the following commands
 
 ```

--- a/examples/node/main.tf
+++ b/examples/node/main.tf
@@ -48,7 +48,7 @@ data "archive_file" "zip_code" {
   output_path = "${path.module}/build/hello-node.zip"
 }
 
-module "example_lambda_function" {
+module "lambda-datadog" {
   source = "../../"
 
   filename      = "${path.module}/build/hello-node.zip"
@@ -62,6 +62,7 @@ module "example_lambda_function" {
     "DD_API_KEY_SECRET_ARN" : var.datadog_secret_arn
     "DD_ENV" : "dev"
     "DD_SERVICE" : var.datadog_service_name
+    "DD_SITE": var.datadog_site
     "DD_VERSION" : "1.0.0"
   }
 }

--- a/examples/node/outputs.tf
+++ b/examples/node/outputs.tf
@@ -1,14 +1,14 @@
 output "arn" {
   description = "Amazon Resource Name (ARN) identifying your Lambda Function."
-  value       = module.example_lambda_function.arn
+  value       = module.lambda-datadog.arn
 }
 
 output "invoke_arn" {
   description = "ARN to be used for invoking Lambda Function from API Gateway."
-  value       = module.example_lambda_function.invoke_arn
+  value       = module.lambda-datadog.invoke_arn
 }
 
 output "function_name" {
   description = "Unique name for your Lambda Function"
-  value       = module.example_lambda_function.function_name
+  value       = module.lambda-datadog.function_name
 }

--- a/examples/node/variables.tf
+++ b/examples/node/variables.tf
@@ -7,3 +7,8 @@ variable "datadog_service_name" {
   description = "Service used to filter for resources in Datadog"
   type        = string
 }
+
+variable "datadog_site" {
+  description = "Destination site for your metrics, traces, and logs"
+  type        = string
+}

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -9,6 +9,7 @@ A simple Python Lambda function with out of the box Datadog instrumentation.
 * Create a `terraform.tfvars` file
   - Set the `datadog_secret_arn` to the arn of the secret you just created
   - Set the `datadog_service_name` to the name of the service you want to use to filter for the resource in Datadog
+  - Set the `datadog_site` to the [Datadog destination site](https://docs.datadoghq.com/getting_started/site/) for your metrics, traces, and logs
 * Run the following commands
 
 ```

--- a/examples/python/main.tf
+++ b/examples/python/main.tf
@@ -48,7 +48,7 @@ data "archive_file" "zip_code" {
   output_path = "${path.module}/build/hello-python.zip"
 }
 
-module "example_lambda_function" {
+module "lambda-datadog" {
   source = "../../"
 
   filename      = "${path.module}/build/hello-python.zip"
@@ -63,6 +63,7 @@ module "example_lambda_function" {
     "DD_API_KEY_SECRET_ARN" : var.datadog_secret_arn
     "DD_ENV" : "dev"
     "DD_SERVICE" : var.datadog_service_name
+    "DD_SITE": var.datadog_site
     "DD_VERSION" : "1.0.0"
   }
 }

--- a/examples/python/outputs.tf
+++ b/examples/python/outputs.tf
@@ -1,14 +1,14 @@
 output "arn" {
   description = "Amazon Resource Name (ARN) identifying your Lambda Function."
-  value       = module.example_lambda_function.arn
+  value       = module.lambda-datadog.arn
 }
 
 output "invoke_arn" {
   description = "ARN to be used for invoking Lambda Function from API Gateway."
-  value       = module.example_lambda_function.invoke_arn
+  value       = module.lambda-datadog.invoke_arn
 }
 
 output "function_name" {
   description = "Unique name for your Lambda Function"
-  value       = module.example_lambda_function.function_name
+  value       = module.lambda-datadog.function_name
 }

--- a/examples/python/variables.tf
+++ b/examples/python/variables.tf
@@ -7,3 +7,8 @@ variable "datadog_service_name" {
   description = "Service used to filter for resources in Datadog"
   type        = string
 }
+
+variable "datadog_site" {
+  description = "Destination site for your metrics, traces, and logs"
+  type        = string
+}


### PR DESCRIPTION
### What does this PR do?

- Renames module examples
- Shows how to pin module version
- Documents `DD_SITE` environment variable

### Motivation

Update readme to be consistent with Datadog public docs.

https://docs.datadoghq.com/serverless/aws_lambda/installation/python/?tab=terraform

### Additional Notes

### Describe how to test/QA your changes

Follow the instructions using one of the examples to deploy a Lambda function instrumented with Datadog to AWS.