### PR TITLE
Bump Module Version to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This Terraform module wraps the [aws_lambda_function](https://registry.terraform
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "1.0.0"
+  version = "1.1.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -42,7 +42,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "1.0.0"
+  version = "1.1.0"
 
   filename      = "example.zip"
   function_name = "example-function"

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ locals {
   }
 
   tags = {
-    dd_sls_terraform_module = "1.0.0"
+    dd_sls_terraform_module = "1.1.0"
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

Bumps module version to 1.1.0.

### Motivation

Upcoming release of 1.1.0.

### Additional Notes

### Describe how to test/QA your changes

Follow the instructions using one of the examples to deploy a Lambda function instrumented with Datadog to AWS.