### PR TITLE
Automatically Create IAM Policy to Read from Secrets Manager

### DIFF
--- a/examples/node/main.tf
+++ b/examples/node/main.tf
@@ -16,30 +16,9 @@ resource "aws_iam_role" "lambda_role" {
   })
 }
 
-resource "aws_iam_policy" "secrets_manager_read_policy" {
-  name        = "terraform-example-node-${var.datadog_service_name}-secrets-manager-policy"
-  description = "Policy to allow read access to Secrets Manager"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid      = "ReadSecret"
-        Effect   = "Allow"
-        Action   = "secretsmanager:GetSecretValue"
-        Resource = var.datadog_secret_arn
-      }
-    ]
-  })
-}
-
 resource "aws_iam_role_policy_attachment" "attach_iam_policy_to_iam_role" {
   role       = aws_iam_role.lambda_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-}
-
-resource "aws_iam_role_policy_attachment" "attach_secrets_manager_policy" {
-  role       = aws_iam_role.lambda_role.name
-  policy_arn = aws_iam_policy.secrets_manager_read_policy.arn
 }
 
 data "archive_file" "zip_code" {

--- a/examples/python/main.tf
+++ b/examples/python/main.tf
@@ -16,30 +16,9 @@ resource "aws_iam_role" "lambda_role" {
   })
 }
 
-resource "aws_iam_policy" "secrets_manager_read_policy" {
-  name        = "terraform-example-python-${var.datadog_service_name}-secrets-manager-policy"
-  description = "Policy to allow read access to Secrets Manager"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid      = "ReadSecret"
-        Effect   = "Allow"
-        Action   = "secretsmanager:GetSecretValue"
-        Resource = var.datadog_secret_arn
-      }
-    ]
-  })
-}
-
 resource "aws_iam_role_policy_attachment" "attach_iam_policy_to_iam_role" {
   role       = aws_iam_role.lambda_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-}
-
-resource "aws_iam_role_policy_attachment" "attach_secrets_manager_policy" {
-  role       = aws_iam_role.lambda_role.name
-  policy_arn = aws_iam_policy.secrets_manager_read_policy.arn
 }
 
 data "archive_file" "zip_code" {

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,30 @@
+locals {
+  role_split                         = split("/", aws_lambda_function.this.role)
+  role_name                          = local.role_split[length(local.role_split) - 1]
+  create_secrets_manager_read_policy = var.datadog_grant_read_secret_permissions && lookup(var.environment_variables, "DD_API_KEY_SECRET_ARN", null) != null ? 1 : 0
+}
+
+data "aws_iam_policy_document" "secrets_manager_read_policy_document" {
+  count = local.create_secrets_manager_read_policy
+  statement {
+    sid       = "ReadSecret"
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [var.environment_variables["DD_API_KEY_SECRET_ARN"]]
+  }
+}
+
+resource "random_uuid" "aws_iam_policy_uuid" {}
+
+resource "aws_iam_policy" "secrets_manager_read_policy" {
+  count       = local.create_secrets_manager_read_policy
+  name        = "lambda-datadog-terraform-secrets-manager-read-policy-${random_uuid.aws_iam_policy_uuid.result}"
+  description = "Allow read permissions to Datadog API Key in Secrets Manager"
+  policy      = data.aws_iam_policy_document.secrets_manager_read_policy_document[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "attach_secrets_manager_read_policy" {
+  count      = local.create_secrets_manager_read_policy
+  role       = local.role_name
+  policy_arn = aws_iam_policy.secrets_manager_read_policy[0].arn
+}

--- a/main.tf
+++ b/main.tf
@@ -229,8 +229,13 @@ resource "aws_iam_policy" "secrets_manager_read_policy" {
   })
 }
 
+locals {
+  role_split = split("/", aws_lambda_function.this.role)
+  role_name  = local.role_split[length(local.role_split) - 1]
+}
+
 resource "aws_iam_role_policy_attachment" "attach_secrets_manager_policy" {
   count      = lookup(var.environment_variables, "DD_API_KEY_SECRET_ARN", null) != null ? 1 : 0
-  role       = split("role/", aws_lambda_function.this.role)[1]
+  role       = local.role_name
   policy_arn = aws_iam_policy.secrets_manager_read_policy[0].arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,12 @@ variable "datadog_extension_layer_version" {
   default     = 58
 }
 
+variable "datadog_grant_read_secret_permissions" {
+  description = "Grant read secret permissions to the Lambda Function for the secret storing the Datadog API key in AWS Secrets Manager."
+  type        = bool
+  default     = true
+}
+
 variable "datadog_node_layer_version" {
   description = "Version for the Datadog Node Layer"
   type        = number


### PR DESCRIPTION
### What does this PR do?

Creates an IAM policy that allows the Lambda function to read from the secret specified in the `DD_API_KEY_SECRET_ARN` environment variable and attaches it to the Lambda Execution role.

### Motivation

Reduce setup time when using Secrets Manager to retrieve Datadog API key.

https://datadoghq.atlassian.net/browse/SVLS-4982

https://docs.datadoghq.com/serverless/aws_lambda/installation/python/?tab=terraform

### Additional Notes

- Only creates IAM policy if `DD_API_KEY_SECRET_ARN` environment variable is set
- Unique identifier appended to end of IAM policy name if multiple need to be created
- Lambda Execution role name parsed from role arn by reading all of the text after the last `/`

### Describe how to test/QA your changes

Follow the instructions using one of the examples to deploy a Lambda function instrumented with Datadog to AWS.