### PR TITLE
Add Java and .NET Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ terraform.rc
 .terraform.lock.hcl
 
 build
+target
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,6 @@ terraform.rc
 
 build
 target
+bin
+obj
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -64,6 +64,58 @@ module "lambda-datadog" {
 }
 ```
 
+### .NET
+```
+module "lambda-datadog" {
+  source  = "DataDog/lambda-datadog/aws"
+  version = "1.1.0"
+
+  filename      = "example.zip"
+  function_name = "example-function"
+  role          = aws_iam_role.lambda_role.arn
+  handler       = "HelloWorld::HelloWorld.Function::Handler"
+  runtime       = "dotnet8"
+  memory_size   = 256
+
+  environment_variables = {
+    "DD_API_KEY_SECRET_ARN" : "arn:aws:secretsmanager:us-east-1:000000000000:secret:example-secret"
+    "DD_ENV" : "dev"
+    "DD_SERVICE" : "example-service"
+    "DD_SITE": "datadoghq.com"
+    "DD_VERSION" : "1.0.0"
+  }
+
+  datadog_extension_layer_version = 58
+  datadog_dotnet_layer_version = 15
+}
+```
+
+### Java
+```
+module "lambda-datadog" {
+  source  = "DataDog/lambda-datadog/aws"
+  version = "1.1.0"
+
+  filename      = "example.jar"
+  function_name = "example-function"
+  role          = aws_iam_role.lambda_role.arn
+  handler       = "com.serverless.Handler"
+  runtime       = "java21"
+  memory_size   = 1024
+
+  environment_variables = {
+    "DD_API_KEY_SECRET_ARN" : "arn:aws:secretsmanager:us-east-1:000000000000:secret:example-secret"
+    "DD_ENV" : "dev"
+    "DD_SERVICE" : "example-service"
+    "DD_SITE": "datadoghq.com"
+    "DD_VERSION" : "1.0.0"
+  }
+
+  datadog_extension_layer_version = 58
+  datadog_java_layer_version = 14
+}
+```
+
 ## Configuration
 
 ### Lambda Function
@@ -119,6 +171,8 @@ Use the following variables to select the versions of the Datadog Lambda layers 
 | Variable | Description |
 | -------- | ----------- |
 | `datadog_extension_layer_version` | Version of the [Datadog Lambda Extension layer](https://github.com/DataDog/datadog-lambda-extension/releases) to install |
+| `datadog_dotnet_layer_version` | Version of the [Datadog .NET Lambda layer](https://github.com/DataDog/dd-trace-dotnet-aws-lambda-layer/releases) to install |
+| `datadog_java_layer_version` | Version of the [Datadog Java Lambda layer](https://github.com/DataDog/datadog-lambda-java/releases) to install |
 | `datadog_node_layer_version` | Version of the [Datadog Node Lambda layer](https://github.com/DataDog/datadog-lambda-js/releases) to install |
 | `datadog_python_layer_version` | Version of the [Datadog Python Lambda layer](https://github.com/DataDog/datadog-lambda-python/releases) to install |
 
@@ -132,6 +186,8 @@ Use Environment variables to configure Datadog Serverless Monitoring. Refer to t
 
 * [Serverless Agent Configuration](https://docs.datadoghq.com/serverless/guide/agent_configuration/)
 * Tracer Configuration
+  - [.NET](https://docs.datadoghq.com/tracing/trace_collection/library_config/dotnet-framework/?tab=environmentvariables)
+  - [Java](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/)
   - [Node](https://github.com/DataDog/datadog-lambda-js?tab=readme-ov-file#configuration)
   - [Python](https://github.com/DataDog/datadog-lambda-python?tab=readme-ov-file#configuration)
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ module "lambda-datadog" {
   filename      = "example.zip"
   function_name = "example-function"
   role          = aws_iam_role.lambda_role.arn
-  handler       = "HelloWorld::HelloWorld.Function::Handler"
+  handler       = "Example::Example.Function::Handler"
   runtime       = "dotnet8"
   memory_size   = 256
 
@@ -99,7 +99,7 @@ module "lambda-datadog" {
   filename      = "example.jar"
   function_name = "example-function"
   role          = aws_iam_role.lambda_role.arn
-  handler       = "com.serverless.Handler"
+  handler       = "com.example.Handler"
   runtime       = "java21"
   memory_size   = 1024
 
@@ -136,6 +136,7 @@ resource "aws_lambda_function" "example_lambda_function" {
     variables = {
         "DD_API_KEY_SECRET_ARN" : "arn:aws:secretsmanager:us-east-1:000000000000:secret:example-secret"
         "DD_ENV" : "dev"
+        "DD_SITE": "datadoghq.com"
         "DD_SERVICE" : "example-service"
         "DD_VERSION" : "1.0.0"
     }
@@ -146,8 +147,9 @@ resource "aws_lambda_function" "example_lambda_function" {
 
 #### Datadog Terraform module for AWS Lambda
 ```
-module "example_lambda_function" {
-  source = "Datadog/lambda-datadog/aws"
+module "lambda-datadog" {
+  source  = "DataDog/lambda-datadog/aws"
+  version = "1.1.0"
 
   function_name = "example-function"  
   ...
@@ -155,6 +157,7 @@ module "example_lambda_function" {
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "arn:aws:secretsmanager:us-east-1:000000000000:secret:example-secret"
     "DD_ENV" : "dev"
+    "DD_SITE": "datadoghq.com"
     "DD_SERVICE" : "example-service"
     "DD_VERSION" : "1.0.0"
   }

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ No modules.
 | <a name="input_architectures"></a> [architectures](#input\_architectures) | Instruction set architecture for your Lambda function. Valid values are ["x86\_64"] and ["arm64"]. | `list(string)` | <pre>["x86_64"]</pre> | no |
 | <a name="input_code_signing_config_arn"></a> [code\_signing\_config\_arn](#input\_code\_signing\_config\_arn) | To enable code signing for this function, specify the ARN of a code-signing configuration. A code-signing configuration includes a set of signing profiles, which define the trusted publishers for this function. | `string` | `null` | no |
 | <a name="input_datadog_extension_layer_version"></a> [datadog\_extension\_layer\_version](#input\_datadog\_extension\_layer\_version) | Version for the Datadog Extension Layer | `number` | `58` | no |
+| <a name="input_datadog_dotnet_layer_version"></a> [datadog\_dotnet\_layer\_version](#input\_datadog\_dotnet\_layer\_version) | Version for the Datadog .NET Layer | `number` | `15` | no |
+| <a name="input_datadog_java_layer_version"></a> [datadog\_java\_layer\_version](#input\_datadog\_java\_layer\_version) | Version for the Datadog Java Layer | `number` | `14` | no |
 | <a name="input_datadog_node_layer_version"></a> [datadog\_node\_layer\_version](#input\_datadog\_node\_layer\_version) | Version for the Datadog Node Layer | `number` | `112` | no |
 | <a name="input_datadog_python_layer_version"></a> [datadog\_python\_layer\_version](#input\_datadog\_python\_layer\_version) | Version for the Datadog Python Layer | `number` | `95` | no |
 | <a name="input_dead_letter_config_target_arn"></a> [dead\_letter\_config\_target\_arn](#input\_dead\_letter\_config\_target\_arn) | ARN of an SNS topic or SQS queue to notify when an invocation fails. | `string` | `null` | no |

--- a/examples/dotnet/README.md
+++ b/examples/dotnet/README.md
@@ -20,6 +20,8 @@ terraform plan
 terraform apply
 ```
 
+If using `arm64` architecture then build the lambda package with the `-farch arm64` argument.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/examples/dotnet/README.md
+++ b/examples/dotnet/README.md
@@ -1,0 +1,68 @@
+# .NET Example
+
+A simple .NET Lambda function with out of the box Datadog instrumentation.
+
+## Usage
+
+* Create a [Datadog API Key](https://app.datadoghq.com/organization-settings/api-keys)
+* Create a secret in [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html) and add the Datadog API Key as the secret value in plaintext
+* Create a `terraform.tfvars` file
+  - Set the `datadog_secret_arn` to the arn of the secret you just created
+  - Set the `datadog_service_name` to the name of the service you want to use to filter for the resource in Datadog
+  - Set the `datadog_site` to the [Datadog destination site](https://docs.datadoghq.com/getting_started/site/) for your metrics, traces, and logs
+* Run the following commands
+
+```
+dotnet restore ./src/HelloWorld
+dotnet lambda package --configuration Debug --framework net8.0 --output-package src/HelloWorld/bin/release/net8.0/hello-dotnet.zip --project-location ./src/HelloWorld
+terraform init
+terraform plan
+terraform apply
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.4.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_example_lambda_function"></a> [example\_lambda\_function](#module\_example\_lambda\_function) | ../../ | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.secrets_manager_read_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.lambda_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.attach_iam_policy_to_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.attach_secrets_manager_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [archive_file.zip_code](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_secret_arn"></a> [secret\_arn](#input\_secret\_arn) | Secret for Datadog API Key | `string` | n/a | yes |
+| <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Service used to filter for resources in Datadog | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | Amazon Resource Name (ARN) identifying your Lambda Function. |
+| <a name="output_function_name"></a> [function\_name](#output\_function\_name) | Unique name for your Lambda Function |
+| <a name="output_invoke_arn"></a> [invoke\_arn](#output\_invoke\_arn) | ARN to be used for invoking Lambda Function from API Gateway. |
+<!-- END_TF_DOCS -->

--- a/examples/dotnet/README.md
+++ b/examples/dotnet/README.md
@@ -39,7 +39,7 @@ terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_example_lambda_function"></a> [example\_lambda\_function](#module\_example\_lambda\_function) | ../../ | n/a |
+| <a name="module_lambda-datadog"></a> [lambda-datadog](#module\_lambda-datadog) | ../../ | n/a |
 
 ## Resources
 
@@ -55,8 +55,9 @@ terraform apply
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_secret_arn"></a> [secret\_arn](#input\_secret\_arn) | Secret for Datadog API Key | `string` | n/a | yes |
-| <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Service used to filter for resources in Datadog | `string` | n/a | yes |
+| <a name="input_datadog_secret_arn"></a> [datadog\_secret\_arn](#input\_datadog\_secret\_arn) | Secret for Datadog API Key | `string` | n/a | yes |
+| <a name="input_datadog_service_name"></a> [datadog\_service\_name](#input\_datadog\_service\_name) | Service used to filter for resources in Datadog | `string` | n/a | yes |
+| <a name="input_datadog_site"></a> [datadog\_site](#input\_datadog\_site) | Destination site for your metrics, traces, and logs | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/dotnet/main.tf
+++ b/examples/dotnet/main.tf
@@ -1,0 +1,63 @@
+resource "aws_iam_role" "lambda_role" {
+  name = "terraform-example-dotnet-${var.datadog_service_name}-role"
+  assume_role_policy = jsonencode(
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Sid" : "",
+          "Effect" : "Allow",
+          "Action" : "sts:AssumeRole",
+          "Principal" : {
+            "Service" : "lambda.amazonaws.com"
+          }
+        }
+      ]
+  })
+}
+
+resource "aws_iam_policy" "secrets_manager_read_policy" {
+  name        = "terraform-example-dotnet-${var.datadog_service_name}-secrets-manager-policy"
+  description = "Policy to allow read access to Secrets Manager"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ReadSecret"
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = var.datadog_secret_arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "attach_iam_policy_to_iam_role" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "attach_secrets_manager_policy" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.secrets_manager_read_policy.arn
+}
+
+module "lambda-datadog" {
+  source = "../../"
+
+  filename         = "${path.module}/src/HelloWorld/bin/release/net8.0/hello-dotnet.zip"
+  source_code_hash = filebase64sha256("${path.module}/src/HelloWorld/bin/release/net8.0/hello-dotnet.zip")
+  function_name    = "terraform-example-dotnet-${var.datadog_service_name}-function"
+  role             = aws_iam_role.lambda_role.arn
+  handler          = "HelloWorld::HelloWorld.Function::Handler"
+  runtime          = "dotnet8"
+  memory_size      = 256
+
+  environment_variables = {
+    "DD_API_KEY_SECRET_ARN" : var.datadog_secret_arn
+    "DD_ENV" : "dev"
+    "DD_SERVICE" : var.datadog_service_name
+    "DD_SITE" : var.datadog_site
+    "DD_VERSION" : "1.0.0"
+  }
+}

--- a/examples/dotnet/outputs.tf
+++ b/examples/dotnet/outputs.tf
@@ -1,0 +1,14 @@
+output "arn" {
+  description = "Amazon Resource Name (ARN) identifying your Lambda Function."
+  value       = module.lambda-datadog.arn
+}
+
+output "invoke_arn" {
+  description = "ARN to be used for invoking Lambda Function from API Gateway."
+  value       = module.lambda-datadog.invoke_arn
+}
+
+output "function_name" {
+  description = "Unique name for your Lambda Function"
+  value       = module.lambda-datadog.function_name
+}

--- a/examples/dotnet/src/HelloWorld/Function.cs
+++ b/examples/dotnet/src/HelloWorld/Function.cs
@@ -1,0 +1,14 @@
+using Amazon.Lambda.Core;
+
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+
+namespace HelloWorld
+{
+    public class Function
+    {
+        public string Handler(object input, ILambdaContext context)
+        {
+            return "Hello!";
+        }
+    }
+}

--- a/examples/dotnet/src/HelloWorld/HelloWorld.csproj
+++ b/examples/dotnet/src/HelloWorld/HelloWorld.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+        <AWSProjectType>Lambda</AWSProjectType>
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
+        <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.2.1" />
+    </ItemGroup>
+</Project>

--- a/examples/dotnet/variables.tf
+++ b/examples/dotnet/variables.tf
@@ -1,0 +1,14 @@
+variable "datadog_secret_arn" {
+  description = "Secret for Datadog API Key"
+  type        = string
+}
+
+variable "datadog_service_name" {
+  description = "Service used to filter for resources in Datadog"
+  type        = string
+}
+
+variable "datadog_site" {
+  description = "Destination site for your metrics, traces, and logs"
+  type        = string
+}

--- a/examples/dotnet/versions.tf
+++ b/examples/dotnet/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.32.0"
+    }
+  }
+}

--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -38,7 +38,7 @@ terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_example_lambda_function"></a> [example\_lambda\_function](#module\_example\_lambda\_function) | ../../ | n/a |
+| <a name="module_lambda-datadog"></a> [lambda-datadog](#module\_lambda-datadog) | ../../ | n/a |
 
 ## Resources
 
@@ -54,8 +54,9 @@ terraform apply
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_secret_arn"></a> [secret\_arn](#input\_secret\_arn) | Secret for Datadog API Key | `string` | n/a | yes |
-| <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Service used to filter for resources in Datadog | `string` | n/a | yes |
+| <a name="input_datadog_secret_arn"></a> [datadog\_secret\_arn](#input\_datadog\_secret\_arn) | Secret for Datadog API Key | `string` | n/a | yes |
+| <a name="input_datadog_service_name"></a> [datadog\_service\_name](#input\_datadog\_service\_name) | Service used to filter for resources in Datadog | `string` | n/a | yes |
+| <a name="input_datadog_site"></a> [datadog\_site](#input\_datadog\_site) | Destination site for your metrics, traces, and logs | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -1,0 +1,67 @@
+# Java Example
+
+A simple Java Lambda function with out of the box Datadog instrumentation.
+
+## Usage
+
+* Create a [Datadog API Key](https://app.datadoghq.com/organization-settings/api-keys)
+* Create a secret in [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html) and add the Datadog API Key as the secret value in plaintext
+* Create a `terraform.tfvars` file
+  - Set the `datadog_secret_arn` to the arn of the secret you just created
+  - Set the `datadog_service_name` to the name of the service you want to use to filter for the resource in Datadog
+  - Set the `datadog_site` to the [Datadog destination site](https://docs.datadoghq.com/getting_started/site/) for your metrics, traces, and logs
+* Run the following commands
+
+```
+mvn clean package shade:shade
+terraform init
+terraform plan
+terraform apply
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.4.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_example_lambda_function"></a> [example\_lambda\_function](#module\_example\_lambda\_function) | ../../ | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.secrets_manager_read_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.lambda_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.attach_iam_policy_to_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.attach_secrets_manager_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [archive_file.zip_code](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_secret_arn"></a> [secret\_arn](#input\_secret\_arn) | Secret for Datadog API Key | `string` | n/a | yes |
+| <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Service used to filter for resources in Datadog | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | Amazon Resource Name (ARN) identifying your Lambda Function. |
+| <a name="output_function_name"></a> [function\_name](#output\_function\_name) | Unique name for your Lambda Function |
+| <a name="output_invoke_arn"></a> [invoke\_arn](#output\_invoke\_arn) | ARN to be used for invoking Lambda Function from API Gateway. |
+<!-- END_TF_DOCS -->

--- a/examples/java/main.tf
+++ b/examples/java/main.tf
@@ -1,0 +1,63 @@
+resource "aws_iam_role" "lambda_role" {
+  name = "terraform-example-java-${var.datadog_service_name}-role"
+  assume_role_policy = jsonencode(
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Sid" : "",
+          "Effect" : "Allow",
+          "Action" : "sts:AssumeRole",
+          "Principal" : {
+            "Service" : "lambda.amazonaws.com"
+          }
+        }
+      ]
+  })
+}
+
+resource "aws_iam_policy" "secrets_manager_read_policy" {
+  name        = "terraform-example-java-${var.datadog_service_name}-secrets-manager-policy"
+  description = "Policy to allow read access to Secrets Manager"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ReadSecret"
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = var.datadog_secret_arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "attach_iam_policy_to_iam_role" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "attach_secrets_manager_policy" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.secrets_manager_read_policy.arn
+}
+
+module "lambda-datadog" {
+  source = "../../"
+
+  filename         = "${path.module}/target/hello-world-java-0.1.0-SNAPSHOT.jar"
+  source_code_hash = filebase64sha256("${path.module}/target/hello-world-java-0.1.0-SNAPSHOT.jar")
+  function_name    = "terraform-example-java-${var.datadog_service_name}-function"
+  role             = aws_iam_role.lambda_role.arn
+  handler          = "com.serverless.Handler"
+  runtime          = "java21"
+  memory_size      = 1024
+
+  environment_variables = {
+    "DD_API_KEY_SECRET_ARN" : var.datadog_secret_arn
+    "DD_ENV" : "dev"
+    "DD_SERVICE" : var.datadog_service_name
+    "DD_SITE" : var.datadog_site
+    "DD_VERSION" : "1.0.0"
+  }
+}

--- a/examples/java/outputs.tf
+++ b/examples/java/outputs.tf
@@ -1,0 +1,14 @@
+output "arn" {
+  description = "Amazon Resource Name (ARN) identifying your Lambda Function."
+  value       = module.lambda-datadog.arn
+}
+
+output "invoke_arn" {
+  description = "ARN to be used for invoking Lambda Function from API Gateway."
+  value       = module.lambda-datadog.invoke_arn
+}
+
+output "function_name" {
+  description = "Unique name for your Lambda Function"
+  value       = module.lambda-datadog.function_name
+}

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.serverless</groupId>
+    <artifactId>hello-world-java</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>module-info.class</exclude>
+                                <exclude>META-INF/*</exclude>
+                                <exclude>META-INF/versions/**</exclude>
+                                <exclude>META-INF/services/**</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/examples/java/src/main/java/com/serverless/Handler.java
+++ b/examples/java/src/main/java/com/serverless/Handler.java
@@ -1,0 +1,14 @@
+package com.serverless;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+import java.util.Map;
+
+public class Handler implements RequestHandler<Map<String,Object>, String> {
+
+  @Override
+  public String handleRequest(Map<String,Object> input, Context context) {
+    return "Hello!";
+  }
+}

--- a/examples/java/variables.tf
+++ b/examples/java/variables.tf
@@ -1,0 +1,14 @@
+variable "datadog_secret_arn" {
+  description = "Secret for Datadog API Key"
+  type        = string
+}
+
+variable "datadog_service_name" {
+  description = "Service used to filter for resources in Datadog"
+  type        = string
+}
+
+variable "datadog_site" {
+  description = "Destination site for your metrics, traces, and logs"
+  type        = string
+}

--- a/examples/java/versions.tf
+++ b/examples/java/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.32.0"
+    }
+  }
+}

--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -37,7 +37,7 @@ terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_example_lambda_function"></a> [example\_lambda\_function](#module\_example\_lambda\_function) | ../../ | n/a |
+| <a name="module_lambda-datadog"></a> [lambda-datadog](#module\_lambda-datadog) | ../../ | n/a |
 
 ## Resources
 
@@ -53,8 +53,9 @@ terraform apply
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_secret_arn"></a> [secret\_arn](#input\_secret\_arn) | Secret for Datadog API Key | `string` | n/a | yes |
-| <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Service used to filter for resources in Datadog | `string` | n/a | yes |
+| <a name="input_datadog_secret_arn"></a> [datadog\_secret\_arn](#input\_datadog\_secret\_arn) | Secret for Datadog API Key | `string` | n/a | yes |
+| <a name="input_datadog_service_name"></a> [datadog\_service\_name](#input\_datadog\_service\_name) | Service used to filter for resources in Datadog | `string` | n/a | yes |
+| <a name="input_datadog_site"></a> [datadog\_site](#input\_datadog\_site) | Destination site for your metrics, traces, and logs | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -37,7 +37,7 @@ terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_example_lambda_function"></a> [example\_lambda\_function](#module\_example\_lambda\_function) | ../../ | n/a |
+| <a name="module_lambda-datadog"></a> [lambda-datadog](#module\_lambda-datadog) | ../../ | n/a |
 
 ## Resources
 
@@ -53,8 +53,9 @@ terraform apply
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_secret_arn"></a> [secret\_arn](#input\_secret\_arn) | Secret for Datadog API Key | `string` | n/a | yes |
-| <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Service used to filter for resources in Datadog | `string` | n/a | yes |
+| <a name="input_datadog_secret_arn"></a> [datadog\_secret\_arn](#input\_datadog\_secret\_arn) | Secret for Datadog API Key | `string` | n/a | yes |
+| <a name="input_datadog_service_name"></a> [datadog\_service\_name](#input\_datadog\_service\_name) | Service used to filter for resources in Datadog | `string` | n/a | yes |
+| <a name="input_datadog_site"></a> [datadog\_site](#input\_datadog\_site) | Destination site for your metrics, traces, and logs | `string` | n/a | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ locals {
   datadog_lambda_layer_runtime = lookup(local.runtime_layer_map, var.runtime, "")
   datadog_lambda_layer_version = lookup(local.runtime_base_layer_version_map, local.runtime_base, "")
 
-  datadog_account_id = (data.aws_partition.current.partition == "aws-us-gov") ? "002406178527" : "464622532012"
+  datadog_account_id      = (data.aws_partition.current.partition == "aws-us-gov") ? "002406178527" : "464622532012"
   datadog_layer_name_base = "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.name}:${local.datadog_account_id}:layer"
   datadog_layer_suffix    = lookup(local.architecture_layer_suffix_map, var.architectures[0])
 
@@ -165,7 +165,7 @@ resource "aws_lambda_function" "this" {
   filename      = var.filename
   function_name = var.function_name
   handler       = local.handler
-  kms_key_arn = var.kms_key_arn
+  kms_key_arn   = var.kms_key_arn
 
   # Datadog layers are defined in single element lists
   # This allows for runtimes where a lambda layer is not needed by concatenating an empty list

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,12 @@ locals {
   }
   runtime_base = regex("[a-z]+", var.runtime)
   runtime_base_environment_variable_map = {
+    dotnet = {
+      AWS_LAMBDA_EXEC_WRAPPER = "/opt/datadog_wrapper"
+    }
+    java = {
+      AWS_LAMBDA_EXEC_WRAPPER = "/opt/datadog_wrapper"
+    }
     nodejs = {
       DD_LAMBDA_HANDLER = var.handler
     }
@@ -16,14 +22,25 @@ locals {
     }
   }
   runtime_base_handler_map = {
+    dotnet = var.handler
+    java   = var.handler
     nodejs = "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler"
     python = "datadog_lambda.handler.handler"
   }
   runtime_base_layer_version_map = {
+    dotnet = var.datadog_dotnet_layer_version
+    java   = var.datadog_java_layer_version
     nodejs = var.datadog_node_layer_version
     python = var.datadog_python_layer_version
   }
   runtime_layer_map = {
+    "dotnet6"    = "dd-trace-dotnet"
+    "dotnet7"    = "dd-trace-dotnet"
+    "dotnet8"    = "dd-trace-dotnet"
+    "java8.al2"  = "dd-trace-java"
+    "java11"     = "dd-trace-java"
+    "java17"     = "dd-trace-java"
+    "java21"     = "dd-trace-java"
     "nodejs16.x" = "Datadog-Node16-x"
     "nodejs18.x" = "Datadog-Node18-x"
     "nodejs20.x" = "Datadog-Node20-x"
@@ -40,7 +57,7 @@ locals {
   datadog_extension_layer_suffix = local.datadog_layer_suffix
 
   datadog_lambda_layer_arn     = "${local.datadog_layer_name_base}:${local.datadog_lambda_layer_runtime}${local.datadog_lambda_layer_suffix}:${local.datadog_lambda_layer_version}"
-  datadog_lambda_layer_suffix  = local.runtime_base == "nodejs" ? "" : local.datadog_layer_suffix # nodejs doesn't have a separate layer for ARM
+  datadog_lambda_layer_suffix  = contains(["java", "nodejs"], local.local.runtime_base) ? "" : local.datadog_layer_suffix # java and nodejs don't have separate layers for ARM
   datadog_lambda_layer_runtime = lookup(local.runtime_layer_map, var.runtime, "")
   datadog_lambda_layer_version = lookup(local.runtime_base_layer_version_map, local.runtime_base, "")
 
@@ -77,6 +94,13 @@ check "runtime_support" {
   assert {
     condition = contains(
       [
+        "dotnet6",
+        "dotnet7",
+        "dotnet8",
+        "java8.al2",
+        "java11",
+        "java17",
+        "java21",
         "nodejs16.x",
         "nodejs18.x",
         "nodejs20.x",

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ locals {
   datadog_extension_layer_suffix = local.datadog_layer_suffix
 
   datadog_lambda_layer_arn     = "${local.datadog_layer_name_base}:${local.datadog_lambda_layer_runtime}${local.datadog_lambda_layer_suffix}:${local.datadog_lambda_layer_version}"
-  datadog_lambda_layer_suffix  = contains(["java", "nodejs"], local.local.runtime_base) ? "" : local.datadog_layer_suffix # java and nodejs don't have separate layers for ARM
+  datadog_lambda_layer_suffix  = contains(["java", "nodejs"], local.runtime_base) ? "" : local.datadog_layer_suffix # java and nodejs don't have separate layers for ARM
   datadog_lambda_layer_runtime = lookup(local.runtime_layer_map, var.runtime, "")
   datadog_lambda_layer_version = lookup(local.runtime_base_layer_version_map, local.runtime_base, "")
 

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,18 @@ variable "datadog_extension_layer_version" {
   default     = 58
 }
 
+variable "datadog_dotnet_layer_version" {
+  description = "Version for the Datadog Node Layer"
+  type        = number
+  default     = 15
+}
+
+variable "datadog_java_layer_version" {
+  description = "Version for the Datadog Node Layer"
+  type        = number
+  default     = 14
+}
+
 variable "datadog_node_layer_version" {
   description = "Version for the Datadog Node Layer"
   type        = number


### PR DESCRIPTION
### What does this PR do?

Adds support for Java and .NET Lambda Functions.

### Motivation

Wider support for runtimes.

https://datadoghq.atlassian.net/browse/SVLS-4849

### Additional Notes

Minor updates to readmes so variables are consistent across examples and match what is expected to be passed.

### Describe how to test/QA your changes

Follow the instructions using one of the examples to deploy a Lambda function instrumented with Datadog to AWS.