### PR TITLE
Bump Python Layer version to 96 and Java Layer version to 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ module "lambda-datadog" {
   }
 
   datadog_extension_layer_version = 58
-  datadog_python_layer_version = 95
+  datadog_python_layer_version = 96
 }
 ```
 
@@ -112,7 +112,7 @@ module "lambda-datadog" {
   }
 
   datadog_extension_layer_version = 58
-  datadog_java_layer_version = 14
+  datadog_java_layer_version = 15
 }
 ```
 
@@ -227,9 +227,9 @@ No modules.
 | <a name="input_code_signing_config_arn"></a> [code\_signing\_config\_arn](#input\_code\_signing\_config\_arn) | To enable code signing for this function, specify the ARN of a code-signing configuration. A code-signing configuration includes a set of signing profiles, which define the trusted publishers for this function. | `string` | `null` | no |
 | <a name="input_datadog_extension_layer_version"></a> [datadog\_extension\_layer\_version](#input\_datadog\_extension\_layer\_version) | Version for the Datadog Extension Layer | `number` | `58` | no |
 | <a name="input_datadog_dotnet_layer_version"></a> [datadog\_dotnet\_layer\_version](#input\_datadog\_dotnet\_layer\_version) | Version for the Datadog .NET Layer | `number` | `15` | no |
-| <a name="input_datadog_java_layer_version"></a> [datadog\_java\_layer\_version](#input\_datadog\_java\_layer\_version) | Version for the Datadog Java Layer | `number` | `14` | no |
+| <a name="input_datadog_java_layer_version"></a> [datadog\_java\_layer\_version](#input\_datadog\_java\_layer\_version) | Version for the Datadog Java Layer | `number` | `15` | no |
 | <a name="input_datadog_node_layer_version"></a> [datadog\_node\_layer\_version](#input\_datadog\_node\_layer\_version) | Version for the Datadog Node Layer | `number` | `112` | no |
-| <a name="input_datadog_python_layer_version"></a> [datadog\_python\_layer\_version](#input\_datadog\_python\_layer\_version) | Version for the Datadog Python Layer | `number` | `95` | no |
+| <a name="input_datadog_python_layer_version"></a> [datadog\_python\_layer\_version](#input\_datadog\_python\_layer\_version) | Version for the Datadog Python Layer | `number` | `96` | no |
 | <a name="input_dead_letter_config_target_arn"></a> [dead\_letter\_config\_target\_arn](#input\_dead\_letter\_config\_target\_arn) | ARN of an SNS topic or SQS queue to notify when an invocation fails. | `string` | `null` | no |
 | <a name="input_description"></a> [description](#input\_description) | Description of what your Lambda Function does. | `string` | `null` | no |
 | <a name="input_environment_variables"></a> [environment\_variables](#input\_environment\_variables) | Map of environment variables that are accessible from the function code during execution. | `map(string)` | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -9,15 +9,15 @@ variable "datadog_extension_layer_version" {
 }
 
 variable "datadog_dotnet_layer_version" {
-  description = "Version for the Datadog Node Layer"
+  description = "Version for the Datadog .NET Layer"
   type        = number
   default     = 15
 }
 
 variable "datadog_java_layer_version" {
-  description = "Version for the Datadog Node Layer"
+  description = "Version for the Datadog Java Layer"
   type        = number
-  default     = 14
+  default     = 15
 }
 
 variable "datadog_node_layer_version" {
@@ -29,7 +29,7 @@ variable "datadog_node_layer_version" {
 variable "datadog_python_layer_version" {
   description = "Version for the Datadog Python Layer"
   type        = number
-  default     = 95
+  default     = 96
 }
 
 


### PR DESCRIPTION
### What does this PR do?

Bumps Datadog Python Layer version to 96 and Datadog Java Layer version to 15.

### Motivation

Make latest enhancements and bug fixes in Datadog layers available.

### Additional Notes

### Describe how to test/QA your changes

Follow the instructions using one of the examples to deploy a Lambda function instrumented with Datadog to AWS.