### PR TITLE
Bump Required Terraform Version to at least 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Use Environment variables to configure Datadog Serverless Monitoring. Refer to t
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0 |
 
 ## Providers

--- a/examples/dotnet/README.md
+++ b/examples/dotnet/README.md
@@ -27,7 +27,7 @@ If using `arm64` architecture then build the lambda package with the `-farch arm
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0 |
 
 ## Providers

--- a/examples/dotnet/versions.tf
+++ b/examples/dotnet/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.5.0"
 
   required_providers {
     aws = {

--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -24,7 +24,7 @@ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0 |
 
 ## Providers

--- a/examples/java/versions.tf
+++ b/examples/java/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.5.0"
 
   required_providers {
     aws = {

--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -23,7 +23,7 @@ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0 |
 
 ## Providers

--- a/examples/node/versions.tf
+++ b/examples/node/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.5.0"
 
   required_providers {
     aws = {

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -23,7 +23,7 @@ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0 |
 
 ## Providers

--- a/examples/python/versions.tf
+++ b/examples/python/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.5.0"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.5.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
### What does this PR do?

Bump Required Terraform Version to at least 1.5.0.

### Motivation

Prevent `Unsupported block type...Blocks of type "check" are not expected here.` errors when trying to initialize the module on versions lower than 1.5.0.

https://github.com/DataDog/terraform-aws-lambda-datadog/issues/13

### Additional Notes

https://developer.hashicorp.com/terraform/language/checks

<img width="716" alt="Screenshot 2024-07-10 at 4 21 45 PM" src="https://github.com/DataDog/terraform-aws-lambda-datadog/assets/35278470/413395a4-ec2f-45ee-bed8-4c920c0c530d">

### Describe how to test/QA your changes

Follow the instructions using one of the examples to deploy a Lambda function instrumented with Datadog to AWS.