### PR TITLE
Bump Module Version to 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ module "lambda-datadog" {
     "DD_VERSION" : "1.0.0"
   }
 
-  datadog_extension_layer_version = 58
+  datadog_extension_layer_version = 59
   datadog_python_layer_version = 96
 }
 ```
@@ -59,7 +59,7 @@ module "lambda-datadog" {
     "DD_VERSION" : "1.0.0"
   }
 
-  datadog_extension_layer_version = 58
+  datadog_extension_layer_version = 59
   datadog_node_layer_version = 112
 }
 ```
@@ -85,7 +85,7 @@ module "lambda-datadog" {
     "DD_VERSION" : "1.0.0"
   }
 
-  datadog_extension_layer_version = 58
+  datadog_extension_layer_version = 59
   datadog_dotnet_layer_version = 15
 }
 ```
@@ -111,7 +111,7 @@ module "lambda-datadog" {
     "DD_VERSION" : "1.0.0"
   }
 
-  datadog_extension_layer_version = 58
+  datadog_extension_layer_version = 59
   datadog_java_layer_version = 15
 }
 ```
@@ -225,7 +225,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_architectures"></a> [architectures](#input\_architectures) | Instruction set architecture for your Lambda function. Valid values are ["x86\_64"] and ["arm64"]. | `list(string)` | <pre>["x86_64"]</pre> | no |
 | <a name="input_code_signing_config_arn"></a> [code\_signing\_config\_arn](#input\_code\_signing\_config\_arn) | To enable code signing for this function, specify the ARN of a code-signing configuration. A code-signing configuration includes a set of signing profiles, which define the trusted publishers for this function. | `string` | `null` | no |
-| <a name="input_datadog_extension_layer_version"></a> [datadog\_extension\_layer\_version](#input\_datadog\_extension\_layer\_version) | Version for the Datadog Extension Layer | `number` | `58` | no |
+| <a name="input_datadog_extension_layer_version"></a> [datadog\_extension\_layer\_version](#input\_datadog\_extension\_layer\_version) | Version for the Datadog Extension Layer | `number` | `59` | no |
 | <a name="input_datadog_dotnet_layer_version"></a> [datadog\_dotnet\_layer\_version](#input\_datadog\_dotnet\_layer\_version) | Version for the Datadog .NET Layer | `number` | `15` | no |
 | <a name="input_datadog_java_layer_version"></a> [datadog\_java\_layer\_version](#input\_datadog\_java\_layer\_version) | Version for the Datadog Java Layer | `number` | `15` | no |
 | <a name="input_datadog_node_layer_version"></a> [datadog\_node\_layer\_version](#input\_datadog\_node\_layer\_version) | Version for the Datadog Node Layer | `number` | `112` | no |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ module "lambda-datadog" {
     "DD_VERSION" : "1.0.0"
   }
 
-  datadog_extension_layer_version = 59
+  datadog_extension_layer_version = 58
   datadog_python_layer_version = 96
 }
 ```
@@ -59,7 +59,7 @@ module "lambda-datadog" {
     "DD_VERSION" : "1.0.0"
   }
 
-  datadog_extension_layer_version = 59
+  datadog_extension_layer_version = 58
   datadog_node_layer_version = 112
 }
 ```
@@ -85,7 +85,7 @@ module "lambda-datadog" {
     "DD_VERSION" : "1.0.0"
   }
 
-  datadog_extension_layer_version = 59
+  datadog_extension_layer_version = 58
   datadog_dotnet_layer_version = 15
 }
 ```
@@ -111,7 +111,7 @@ module "lambda-datadog" {
     "DD_VERSION" : "1.0.0"
   }
 
-  datadog_extension_layer_version = 59
+  datadog_extension_layer_version = 58
   datadog_java_layer_version = 15
 }
 ```
@@ -225,7 +225,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_architectures"></a> [architectures](#input\_architectures) | Instruction set architecture for your Lambda function. Valid values are ["x86\_64"] and ["arm64"]. | `list(string)` | <pre>["x86_64"]</pre> | no |
 | <a name="input_code_signing_config_arn"></a> [code\_signing\_config\_arn](#input\_code\_signing\_config\_arn) | To enable code signing for this function, specify the ARN of a code-signing configuration. A code-signing configuration includes a set of signing profiles, which define the trusted publishers for this function. | `string` | `null` | no |
-| <a name="input_datadog_extension_layer_version"></a> [datadog\_extension\_layer\_version](#input\_datadog\_extension\_layer\_version) | Version for the Datadog Extension Layer | `number` | `59` | no |
+| <a name="input_datadog_extension_layer_version"></a> [datadog\_extension\_layer\_version](#input\_datadog\_extension\_layer\_version) | Version for the Datadog Extension Layer | `number` | `58` | no |
 | <a name="input_datadog_dotnet_layer_version"></a> [datadog\_dotnet\_layer\_version](#input\_datadog\_dotnet\_layer\_version) | Version for the Datadog .NET Layer | `number` | `15` | no |
 | <a name="input_datadog_java_layer_version"></a> [datadog\_java\_layer\_version](#input\_datadog\_java\_layer\_version) | Version for the Datadog Java Layer | `number` | `15` | no |
 | <a name="input_datadog_node_layer_version"></a> [datadog\_node\_layer\_version](#input\_datadog\_node\_layer\_version) | Version for the Datadog Node Layer | `number` | `112` | no |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This Terraform module wraps the [aws_lambda_function](https://registry.terraform
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "1.2.0"
+  version = "1.3.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -42,7 +42,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "1.2.0"
+  version = "1.3.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -68,7 +68,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "1.2.0"
+  version = "1.3.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -94,7 +94,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "1.2.0"
+  version = "1.3.0"
 
   filename      = "example.jar"
   function_name = "example-function"
@@ -149,7 +149,7 @@ resource "aws_lambda_function" "example_lambda_function" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "1.2.0"
+  version = "1.3.0"
 
   function_name = "example-function"  
   ...

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,7 @@ locals {
   }
 
   tags = {
-    dd_sls_terraform_module = "1.2.0"
+    dd_sls_terraform_module = "1.3.0"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@
 variable "datadog_extension_layer_version" {
   description = "Version for the Datadog Extension Layer"
   type        = number
-  default     = 58
+  default     = 59
 }
 
 variable "datadog_dotnet_layer_version" {

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@
 variable "datadog_extension_layer_version" {
   description = "Version for the Datadog Extension Layer"
   type        = number
-  default     = 59
+  default     = 58
 }
 
 variable "datadog_dotnet_layer_version" {


### PR DESCRIPTION
### What does this PR do?

Bumps module version to 1.3.0.

### Motivation

Upcoming release of 1.3.0.

### Additional Notes

### Describe how to test/QA your changes

Follow the instructions using one of the examples to deploy a Lambda function instrumented with Datadog to AWS.