### PR TITLE
fix: give to `var.handler` priority for `python` runtime

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ locals {
     runtime = lookup(local.runtime_base_environment_variable_map, local.runtime_base, {})
   }
 
-  handler = lookup(local.runtime_base_handler_map, local.runtime_base, var.handler)
+  handler = coalesce(var.handler, lookup(local.runtime_base_handler_map, local.runtime_base))
 
   layers = {
     extension = [local.datadog_extension_layer_arn]


### PR DESCRIPTION
### What does this PR do?
This pull request wants to address the following issue: https://github.com/DataDog/terraform-aws-lambda-datadog/issues/19
In other words, we want to give priority to the `var.handler` variable over the default values set by DataDog.

### Motivation
When we migrate from `aws_lambda_function` to `lambda-datadog` we do not need to change the handler name for the already existing functions.
In fact, we do not want to delete and recreate the existing functions, we want to migrate them to the new `lambda-datadog` one.

### Additional Notes

### Describe how to test/QA your changes
Try to deploy a lambda function with:
```terraform
   runtime          = "python3.9"
```