### PR TITLE
Add ONE team as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @DataDog/serverless-onboarding-enablement


### PR DESCRIPTION
### What does this PR do?
Make `serverless-onboarding-enablement` team as code owner

### What and why?

1. Team members will be auto-added as a reviewer in a Round Robin way.