### PR TITLE
chore: bump layer versions for v2.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This Terraform module wraps the [aws_lambda_function](https://registry.terraform
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.1.0"
+  version = "3.0.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -42,7 +42,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.1.0"
+  version = "3.0.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -68,7 +68,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.1.0"
+  version = "3.0.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -94,7 +94,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.1.0"
+  version = "3.0.0"
 
   filename      = "example.jar"
   function_name = "example-function"
@@ -149,7 +149,7 @@ resource "aws_lambda_function" "example_lambda_function" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.1.0"
+  version = "3.0.0"
 
   function_name = "example-function"  
   ...

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This Terraform module wraps the [aws_lambda_function](https://registry.terraform
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.0.0"
+  version = "2.1.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -33,7 +33,7 @@ module "lambda-datadog" {
     "DD_VERSION" : "1.0.0"
   }
 
-  datadog_extension_layer_version = 67
+  datadog_extension_layer_version = 74
   datadog_python_layer_version = 106
 }
 ```
@@ -42,7 +42,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.0.0"
+  version = "2.1.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -59,8 +59,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "1.0.0"
   }
 
-  datadog_extension_layer_version = 67
-  datadog_node_layer_version = 117
+  datadog_extension_layer_version = 74
+  datadog_node_layer_version = 123
 }
 ```
 
@@ -68,7 +68,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.0.0"
+  version = "2.1.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -85,8 +85,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "1.0.0"
   }
 
-  datadog_extension_layer_version = 67
-  datadog_dotnet_layer_version = 16
+  datadog_extension_layer_version = 74
+  datadog_dotnet_layer_version = 19
 }
 ```
 
@@ -94,7 +94,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.0.0"
+  version = "2.1.0"
 
   filename      = "example.jar"
   function_name = "example-function"
@@ -111,8 +111,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "1.0.0"
   }
 
-  datadog_extension_layer_version = 67
-  datadog_java_layer_version = 15
+  datadog_extension_layer_version = 74
+  datadog_java_layer_version = 19
 }
 ```
 
@@ -149,7 +149,7 @@ resource "aws_lambda_function" "example_lambda_function" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.0.0"
+  version = "2.1.0"
 
   function_name = "example-function"  
   ...
@@ -225,10 +225,10 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_architectures"></a> [architectures](#input\_architectures) | Instruction set architecture for your Lambda function. Valid values are ["x86\_64"] and ["arm64"]. | `list(string)` | <pre>["x86_64"]</pre> | no |
 | <a name="input_code_signing_config_arn"></a> [code\_signing\_config\_arn](#input\_code\_signing\_config\_arn) | To enable code signing for this function, specify the ARN of a code-signing configuration. A code-signing configuration includes a set of signing profiles, which define the trusted publishers for this function. | `string` | `null` | no |
-| <a name="input_datadog_extension_layer_version"></a> [datadog\_extension\_layer\_version](#input\_datadog\_extension\_layer\_version) | Version for the Datadog Extension Layer | `number` | `67` | no |
-| <a name="input_datadog_dotnet_layer_version"></a> [datadog\_dotnet\_layer\_version](#input\_datadog\_dotnet\_layer\_version) | Version for the Datadog .NET Layer | `number` | `16` | no |
-| <a name="input_datadog_java_layer_version"></a> [datadog\_java\_layer\_version](#input\_datadog\_java\_layer\_version) | Version for the Datadog Java Layer | `number` | `15` | no |
-| <a name="input_datadog_node_layer_version"></a> [datadog\_node\_layer\_version](#input\_datadog\_node\_layer\_version) | Version for the Datadog Node Layer | `number` | `117` | no |
+| <a name="input_datadog_extension_layer_version"></a> [datadog\_extension\_layer\_version](#input\_datadog\_extension\_layer\_version) | Version for the Datadog Extension Layer | `number` | `74` | no |
+| <a name="input_datadog_dotnet_layer_version"></a> [datadog\_dotnet\_layer\_version](#input\_datadog\_dotnet\_layer\_version) | Version for the Datadog .NET Layer | `number` | `19` | no |
+| <a name="input_datadog_java_layer_version"></a> [datadog\_java\_layer\_version](#input\_datadog\_java\_layer\_version) | Version for the Datadog Java Layer | `number` | `19` | no |
+| <a name="input_datadog_node_layer_version"></a> [datadog\_node\_layer\_version](#input\_datadog\_node\_layer\_version) | Version for the Datadog Node Layer | `number` | `123` | no |
 | <a name="input_datadog_python_layer_version"></a> [datadog\_python\_layer\_version](#input\_datadog\_python\_layer\_version) | Version for the Datadog Python Layer | `number` | `106` | no |
 | <a name="input_dead_letter_config_target_arn"></a> [dead\_letter\_config\_target\_arn](#input\_dead\_letter\_config\_target\_arn) | ARN of an SNS topic or SQS queue to notify when an invocation fails. | `string` | `null` | no |
 | <a name="input_description"></a> [description](#input\_description) | Description of what your Lambda Function does. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,7 @@ locals {
   }
 
   tags = {
-    dd_sls_terraform_module = "2.1.0"
+    dd_sls_terraform_module = "3.0.0"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,6 @@ locals {
     "java11"     = "dd-trace-java"
     "java17"     = "dd-trace-java"
     "java21"     = "dd-trace-java"
-    "nodejs16.x" = "Datadog-Node16-x"
     "nodejs18.x" = "Datadog-Node18-x"
     "nodejs20.x" = "Datadog-Node20-x"
     "nodejs22.x" = "Datadog-Node22-x"
@@ -88,7 +87,7 @@ locals {
   }
 
   tags = {
-    dd_sls_terraform_module = "2.0.0"
+    dd_sls_terraform_module = "2.1.0"
   }
 }
 
@@ -103,7 +102,6 @@ check "runtime_support" {
         "java11",
         "java17",
         "java21",
-        "nodejs16.x",
         "nodejs18.x",
         "nodejs20.x",
         "nodejs22.x",

--- a/smoke_tests/main.tf
+++ b/smoke_tests/main.tf
@@ -69,7 +69,7 @@ module "lambda-python-3-13" {
     "DD_API_KEY_SECRET_ARN" : var.datadog_secret_arn
     "DD_ENV" : "dev"
     "DD_SERVICE" : var.datadog_service_name
-    "DD_SITE": var.datadog_site
+    "DD_SITE" : var.datadog_site
     "DD_VERSION" : "1.0.0"
   }
 }
@@ -89,7 +89,7 @@ module "lambda-python-3-12" {
     "DD_API_KEY_SECRET_ARN" : var.datadog_secret_arn
     "DD_ENV" : "dev"
     "DD_SERVICE" : var.datadog_service_name
-    "DD_SITE": var.datadog_site
+    "DD_SITE" : var.datadog_site
     "DD_VERSION" : "1.0.0"
   }
 }
@@ -109,7 +109,7 @@ module "lambda-python-3-11" {
     "DD_API_KEY_SECRET_ARN" : var.datadog_secret_arn
     "DD_ENV" : "dev"
     "DD_SERVICE" : var.datadog_service_name
-    "DD_SITE": var.datadog_site
+    "DD_SITE" : var.datadog_site
     "DD_VERSION" : "1.0.0"
   }
 }
@@ -129,7 +129,7 @@ module "lambda-python-3-10" {
     "DD_API_KEY_SECRET_ARN" : var.datadog_secret_arn
     "DD_ENV" : "dev"
     "DD_SERVICE" : var.datadog_service_name
-    "DD_SITE": var.datadog_site
+    "DD_SITE" : var.datadog_site
     "DD_VERSION" : "1.0.0"
   }
 }
@@ -149,7 +149,7 @@ module "lambda-python-3-9" {
     "DD_API_KEY_SECRET_ARN" : var.datadog_secret_arn
     "DD_ENV" : "dev"
     "DD_SERVICE" : var.datadog_service_name
-    "DD_SITE": var.datadog_site
+    "DD_SITE" : var.datadog_site
     "DD_VERSION" : "1.0.0"
   }
 }
@@ -169,7 +169,7 @@ module "lambda-python-3-8" {
     "DD_API_KEY_SECRET_ARN" : var.datadog_secret_arn
     "DD_ENV" : "dev"
     "DD_SERVICE" : var.datadog_service_name
-    "DD_SITE": var.datadog_site
+    "DD_SITE" : var.datadog_site
     "DD_VERSION" : "1.0.0"
   }
 }
@@ -188,7 +188,7 @@ module "lambda-node-22" {
     "DD_API_KEY_SECRET_ARN" : var.datadog_secret_arn
     "DD_ENV" : "dev"
     "DD_SERVICE" : var.datadog_service_name
-    "DD_SITE": var.datadog_site
+    "DD_SITE" : var.datadog_site
     "DD_VERSION" : "1.0.0"
   }
 }
@@ -207,7 +207,7 @@ module "lambda-node-20" {
     "DD_API_KEY_SECRET_ARN" : var.datadog_secret_arn
     "DD_ENV" : "dev"
     "DD_SERVICE" : var.datadog_service_name
-    "DD_SITE": var.datadog_site
+    "DD_SITE" : var.datadog_site
     "DD_VERSION" : "1.0.0"
   }
 }
@@ -226,26 +226,7 @@ module "lambda-node-18" {
     "DD_API_KEY_SECRET_ARN" : var.datadog_secret_arn
     "DD_ENV" : "dev"
     "DD_SERVICE" : var.datadog_service_name
-    "DD_SITE": var.datadog_site
-    "DD_VERSION" : "1.0.0"
-  }
-}
-
-module "lambda-node-16" {
-  source = "../"
-
-  filename      = "${path.module}/build/hello-node.zip"
-  function_name = "terraform-smoketest-node-16-${var.datadog_service_name}-function"
-  role          = aws_iam_role.lambda_role.arn
-  handler       = "index.lambda_handler"
-  runtime       = "nodejs16.x"
-  memory_size   = 256
-
-  environment_variables = {
-    "DD_API_KEY_SECRET_ARN" : var.datadog_secret_arn
-    "DD_ENV" : "dev"
-    "DD_SERVICE" : var.datadog_service_name
-    "DD_SITE": var.datadog_site
+    "DD_SITE" : var.datadog_site
     "DD_VERSION" : "1.0.0"
   }
 }

--- a/smoke_tests/outputs.tf
+++ b/smoke_tests/outputs.tf
@@ -140,19 +140,3 @@ output "node_18_function_name" {
   description = "Unique name for your Lambda Function"
   value       = module.lambda-node-18.function_name
 }
-
-
-output "node_16_arn" {
-  description = "Amazon Resource Name (ARN) identifying your Lambda Function."
-  value       = module.lambda-node-16.arn
-}
-
-output "node_16_invoke_arn" {
-  description = "ARN to be used for invoking Lambda Function from API Gateway."
-  value       = module.lambda-node-16.invoke_arn
-}
-
-output "node_16_function_name" {
-  description = "Unique name for your Lambda Function"
-  value       = module.lambda-node-16.function_name
-}

--- a/variables.tf
+++ b/variables.tf
@@ -5,25 +5,25 @@
 variable "datadog_extension_layer_version" {
   description = "Version for the Datadog Extension Layer"
   type        = number
-  default     = 67
+  default     = 74
 }
 
 variable "datadog_dotnet_layer_version" {
   description = "Version for the Datadog .NET Layer"
   type        = number
-  default     = 16
+  default     = 19
 }
 
 variable "datadog_java_layer_version" {
   description = "Version for the Datadog Java Layer"
   type        = number
-  default     = 15
+  default     = 19
 }
 
 variable "datadog_node_layer_version" {
   description = "Version for the Datadog Node Layer"
   type        = number
-  default     = 117
+  default     = 123
 }
 
 variable "datadog_python_layer_version" {


### PR DESCRIPTION
Since the lambda layer dropped support for Node 16, in https://github.com/DataDog/datadog-lambda-js/releases/tag/v10.121.0 .