### PR TITLE
Bump Module Version to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This Terraform module wraps the [aws_lambda_function](https://registry.terraform
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.0.0"
+  version = "3.1.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -42,7 +42,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.0.0"
+  version = "3.1.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -68,7 +68,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.0.0"
+  version = "3.1.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -94,7 +94,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.0.0"
+  version = "3.1.0"
 
   filename      = "example.jar"
   function_name = "example-function"
@@ -120,7 +120,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.0.0"
+  version = "3.1.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -182,7 +182,7 @@ resource "aws_lambda_function" "example_lambda_function" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.0.0"
+  version = "3.1.0"
 
   function_name = "example-function"  
   ...

--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,7 @@ locals {
   }
 
   tags = {
-    dd_sls_terraform_module = "3.0.0"
+    dd_sls_terraform_module = "3.1.0"
   }
 }
 


### PR DESCRIPTION
# What does this PR do?
Bump module version to 3.1.0.

# Motivation
Supports go runtime now as a minor issue

# Additional Notes

# Describe how to test/QA your changes
Follow the instructions using one of the examples to deploy a Lambda function instrumented with Datadog to AWS.