### PR TITLE
Bump default layer versions for terraform module

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@
 variable "datadog_extension_layer_version" {
   description = "Version for the Datadog Extension Layer"
   type        = number
-  default     = 81
+  default     = 83
 }
 
 variable "datadog_dotnet_layer_version" {
@@ -17,19 +17,19 @@ variable "datadog_dotnet_layer_version" {
 variable "datadog_java_layer_version" {
   description = "Version for the Datadog Java Layer"
   type        = number
-  default     = 21
+  default     = 23
 }
 
 variable "datadog_node_layer_version" {
   description = "Version for the Datadog Node Layer"
   type        = number
-  default     = 125
+  default     = 126
 }
 
 variable "datadog_python_layer_version" {
   description = "Version for the Datadog Python Layer"
   type        = number
-  default     = 110
+  default     = 112
 }
 
 variable "fips" {


### PR DESCRIPTION
This PR bumps the default versions for the Datadog Lambda Extension, Datadog Java Layer, Datadog Node Layer, and Datadog Python Layer in preparation for a new release.