### PR TITLE
Bump module version to 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This Terraform module wraps the [aws_lambda_function](https://registry.terraform
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.1.0"
+  version = "3.2.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -42,7 +42,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.1.0"
+  version = "3.2.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -68,7 +68,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.1.0"
+  version = "3.2.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -94,7 +94,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.1.0"
+  version = "3.2.0"
 
   filename      = "example.jar"
   function_name = "example-function"
@@ -120,7 +120,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.1.0"
+  version = "3.2.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -182,7 +182,7 @@ resource "aws_lambda_function" "example_lambda_function" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.1.0"
+  version = "3.2.0"
 
   function_name = "example-function"  
   ...

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ locals {
   }
 
   tags = {
-    dd_sls_terraform_module = "3.1.0"
+    dd_sls_terraform_module = "3.2.0"
   }
 }
 


### PR DESCRIPTION
This PR releases version 3.2.0 of the module.

Changes include:
- https://github.com/DataDog/terraform-aws-lambda-datadog/pull/37
- https://github.com/DataDog/terraform-aws-lambda-datadog/pull/36
- https://github.com/DataDog/terraform-aws-lambda-datadog/pull/35
