### PR TITLE
fix: aws provider v5 compatibility

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ locals {
   datadog_lambda_layer_version = lookup(local.runtime_base_layer_version_map, local.runtime_base, "")
 
   datadog_account_id      = (data.aws_partition.current.partition == "aws-us-gov") ? "002406178527" : "464622532012"
-  datadog_layer_name_base = "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.region}:${local.datadog_account_id}:layer"
+  datadog_layer_name_base = "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.name}:${local.datadog_account_id}:layer"
   datadog_layer_suffix    = lookup(local.architecture_layer_suffix_map, var.architectures[0])
 
   environment_variables = {


### PR DESCRIPTION
The AWS Terraform provider v6 has deprecated the `data.aws_region.*.name` attribute in favor of a new `data.aws_region.*.region` attribute. See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region

But this module declares minimum version for this provider as `5.77.0`, so it should not use the new `region` attribute to maintain backwards compatibility.

For users on v6 of AWS provider, there might be a deprecation warning, but it will still work the same.

Fixes: DataDog/terraform-aws-lambda-datadog#40