### PR TITLE
Add variable to disable instrumentation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -145,7 +145,7 @@ resource "aws_lambda_function" "this" {
   # User defined environment variables take precedence over datadog defined environment variables
   # This allows users the option to override default behavior
   environment {
-    variables = merge(
+    variables = var.disable_instrumentation ? var.environment_variables : merge(
       local.environment_variables.common,
       local.environment_variables.runtime,
       var.environment_variables
@@ -171,12 +171,12 @@ resource "aws_lambda_function" "this" {
 
   filename      = var.filename
   function_name = var.function_name
-  handler       = local.handler
+  handler       = var.disable_instrumentation ? var.handler : local.handler
   kms_key_arn   = var.kms_key_arn
 
   # Datadog layers are defined in single element lists
   # This allows for runtimes where a lambda layer is not needed by concatenating an empty list
-  layers = concat(
+  layers = var.disable_instrumentation ? var.layers : concat(
     var.layers,
     local.layers.lambda,
     local.layers.extension,
@@ -215,7 +215,7 @@ resource "aws_lambda_function" "this" {
 
   # Datadog defined tags take precedence over user defined tags
   # This is to ensure that the dd_sls_terraform_module tag is set correctly
-  tags = merge(
+  tags = var.disable_instrumentation ? var.tags : merge(
     var.tags,
     local.tags
   )

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,12 @@
 # Datadog
 ###########
 
+variable "disable_instrumentation" {
+  description = "If true, will disable the instrumentation completely, and deploy the lambda as is"
+  type        = bool
+  default     = false
+}
+
 variable "datadog_extension_layer_version" {
   description = "Version for the Datadog Extension Layer"
   type        = number


### PR DESCRIPTION
I want to be able to enable or disable instrumentation for my lambdas selectively based on which environment I deploy to.

It's currently inconvenient to do so using this module, as I would need to have a regular lambda resource when deploying without instrumentation, but would need to use the module when enabling. That's definitely possible using conditional activation with count attributes, but:
- It requires duplicated configuration for both regular and wrapped lambda
- enabling / disabling instrumentation would recreate the lambda (unless doing a manual move operation)

This PR adds a single `disable_instrumentation` variable to disable all customizations performed by the module, acting as a pass-through wrapper for the aws_lambda_function resource.