### PR TITLE
Bump module version to 4.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This Terraform module wraps the [aws_lambda_function](https://registry.terraform
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "4.6.1"
+  version = "4.7.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -44,7 +44,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "4.6.1"
+  version = "4.7.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -72,7 +72,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "4.6.1"
+  version = "4.7.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -100,7 +100,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "4.6.1"
+  version = "4.7.0"
 
   filename      = "example.jar"
   function_name = "example-function"
@@ -128,7 +128,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "4.6.1"
+  version = "4.7.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -155,7 +155,7 @@ module "lambda-datadog" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "4.6.1"
+  version = "4.7.0"
 
   filename      = "example.zip"
   function_name = "example-function"
@@ -221,7 +221,7 @@ resource "aws_lambda_function" "example_lambda_function" {
 ```
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "4.6.1"
+  version = "4.7.0"
 
   function_name = "example-function"  
   ...

--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,7 @@ locals {
   }
 
   tags = {
-    dd_sls_terraform_module = "4.6.1"
+    dd_sls_terraform_module = "4.7.0"
   }
 }
 


### PR DESCRIPTION
## Summary
- Bump module version `4.6.1` → `4.7.0` in `main.tf` and `README.md`
- Minor bump for Ruby 4 runtime support added in #101

## Test plan
- [ ] CI passes
- [ ] After merge, draft `v4.7.0` GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)