### PR TITLE
chore: add e2e Terraform fixture

### DIFF
--- a/e2e/fixture/main.tf
+++ b/e2e/fixture/main.tf
@@ -1,0 +1,113 @@
+locals {
+  handler = "index.handler"
+
+  # The instrumented (module) and uninstrumented (bare) variants are genuinely different
+  # resources -- removing a wrapper module and replacing it with a plain aws_lambda_function
+  # is how a user actually un-instruments. They use distinct physical function names so they
+  # never collide during the create/destroy of a toggle, while DD_SERVICE keeps a single
+  # stable workload identity for telemetry correlation across phases.
+  instrumented_function_name   = var.service_name
+  uninstrumented_function_name = "${var.service_name}-base"
+
+  # Freshness + identity tags applied atomically at creation. The cross-repo sweeper
+  # lists by the one-e2e- name prefix and uses one_e2e_created to skip in-flight runs.
+  common_tags = {
+    one_e2e_created = var.created_ts
+    one_e2e_run_id  = var.run_id
+  }
+}
+
+resource "aws_iam_role" "lambda" {
+  name = "${var.service_name}-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Action    = "sts:AssumeRole"
+        Principal = { Service = "lambda.amazonaws.com" }
+      }
+    ]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "basic_execution" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "read_secret" {
+  name = "read-dd-api-key-secret"
+  role = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = var.datadog_api_key_secret_arn
+      }
+    ]
+  })
+}
+
+data "archive_file" "handler" {
+  type        = "zip"
+  source_dir  = "${path.module}/src/"
+  output_path = "${path.module}/build/handler.zip"
+}
+
+# Instrumented: the workload is defined through the module under test.
+module "instrumented" {
+  count  = var.instrumented ? 1 : 0
+  source = "../../"
+
+  filename         = data.archive_file.handler.output_path
+  source_code_hash = data.archive_file.handler.output_base64sha256
+  function_name    = local.instrumented_function_name
+  role             = aws_iam_role.lambda.arn
+  handler          = local.handler
+  runtime          = var.runtime
+  memory_size      = 256
+
+  datadog_extension_layer_version = var.datadog_extension_layer_version
+  datadog_node_layer_version      = var.datadog_node_layer_version
+
+  environment_variables = {
+    DD_API_KEY_SECRET_ARN = var.datadog_api_key_secret_arn
+    DD_ENV                = var.dd_env
+    DD_SERVICE            = var.service_name
+    DD_SITE               = var.datadog_site
+    DD_VERSION            = var.dd_version
+    DD_TAGS               = "one_e2e_run_id:${var.run_id}"
+    ONE_E2E_RUN_ID        = var.run_id
+  }
+
+  tags = local.common_tags
+}
+
+# Uninstrumented: the same workload defined as a bare function, with no Datadog wiring.
+# This is the provisioning baseline and the post-REMOVE clean end-state.
+resource "aws_lambda_function" "uninstrumented" {
+  count = var.instrumented ? 0 : 1
+
+  filename         = data.archive_file.handler.output_path
+  source_code_hash = data.archive_file.handler.output_base64sha256
+  function_name    = local.uninstrumented_function_name
+  role             = aws_iam_role.lambda.arn
+  handler          = local.handler
+  runtime          = var.runtime
+  memory_size      = 256
+
+  environment {
+    variables = {
+      ONE_E2E_RUN_ID = var.run_id
+    }
+  }
+
+  tags = local.common_tags
+}

--- a/e2e/fixture/main.tf
+++ b/e2e/fixture/main.tf
@@ -1,14 +1,6 @@
 locals {
   handler = "index.handler"
 
-  # The instrumented (module) and uninstrumented (bare) variants are genuinely different
-  # resources -- removing a wrapper module and replacing it with a plain aws_lambda_function
-  # is how a user actually un-instruments. They use distinct physical function names so they
-  # never collide during the create/destroy of a toggle, while DD_SERVICE keeps a single
-  # stable workload identity for telemetry correlation across phases.
-  instrumented_function_name   = var.service_name
-  uninstrumented_function_name = "${var.service_name}-base"
-
   # Freshness + identity tags applied atomically at creation. The cross-repo sweeper
   # lists by the one-e2e- name prefix and uses one_e2e_created to skip in-flight runs.
   common_tags = {
@@ -61,14 +53,15 @@ data "archive_file" "handler" {
   output_path = "${path.module}/build/handler.zip"
 }
 
-# Instrumented: the workload is defined through the module under test.
+# The workload is defined through the module under test. APPLY creates it from nothing;
+# toggling `instrumented` off (REMOVE) destroys it, leaving a clean end-state (no function).
 module "instrumented" {
   count  = var.instrumented ? 1 : 0
   source = "../../"
 
   filename         = data.archive_file.handler.output_path
   source_code_hash = data.archive_file.handler.output_base64sha256
-  function_name    = local.instrumented_function_name
+  function_name    = var.service_name
   role             = aws_iam_role.lambda.arn
   handler          = local.handler
   runtime          = var.runtime
@@ -85,28 +78,6 @@ module "instrumented" {
     DD_VERSION            = var.dd_version
     DD_TAGS               = "one_e2e_run_id:${var.run_id}"
     ONE_E2E_RUN_ID        = var.run_id
-  }
-
-  tags = local.common_tags
-}
-
-# Uninstrumented: the same workload defined as a bare function, with no Datadog wiring.
-# This is the provisioning baseline and the post-REMOVE clean end-state.
-resource "aws_lambda_function" "uninstrumented" {
-  count = var.instrumented ? 0 : 1
-
-  filename         = data.archive_file.handler.output_path
-  source_code_hash = data.archive_file.handler.output_base64sha256
-  function_name    = local.uninstrumented_function_name
-  role             = aws_iam_role.lambda.arn
-  handler          = local.handler
-  runtime          = var.runtime
-  memory_size      = 256
-
-  environment {
-    variables = {
-      ONE_E2E_RUN_ID = var.run_id
-    }
   }
 
   tags = local.common_tags

--- a/e2e/fixture/outputs.tf
+++ b/e2e/fixture/outputs.tf
@@ -1,0 +1,14 @@
+output "service_name" {
+  description = "Stable workload identity (DD_SERVICE) across phases."
+  value       = var.service_name
+}
+
+output "function_name" {
+  description = "Physical name of the active Lambda variant (instrumented or bare)."
+  value       = var.instrumented ? local.instrumented_function_name : local.uninstrumented_function_name
+}
+
+output "function_arn" {
+  description = "ARN of the active Lambda variant."
+  value       = var.instrumented ? module.instrumented[0].arn : aws_lambda_function.uninstrumented[0].arn
+}

--- a/e2e/fixture/outputs.tf
+++ b/e2e/fixture/outputs.tf
@@ -1,14 +1,9 @@
-output "service_name" {
-  description = "Stable workload identity (DD_SERVICE) across phases."
-  value       = var.service_name
-}
-
 output "function_name" {
-  description = "Physical name of the active Lambda variant (instrumented or bare)."
-  value       = var.instrumented ? local.instrumented_function_name : local.uninstrumented_function_name
+  description = "Physical name of the instrumented Lambda (null when removed)."
+  value       = one(module.instrumented[*].function_name)
 }
 
 output "function_arn" {
-  description = "ARN of the active Lambda variant."
-  value       = var.instrumented ? module.instrumented[0].arn : aws_lambda_function.uninstrumented[0].arn
+  description = "ARN of the instrumented Lambda (null when removed)."
+  value       = one(module.instrumented[*].arn)
 }

--- a/e2e/fixture/provider.tf
+++ b/e2e/fixture/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.region
+}

--- a/e2e/fixture/src/index.js
+++ b/e2e/fixture/src/index.js
@@ -1,0 +1,12 @@
+// Minimal hello-world workload duplicated from serverless-self-monitoring
+// (lambda-managed-instances/handlers/default/nodejs). Tracing is auto-injected by the
+// Datadog layers and logs are auto-collected by the extension, so no tracer setup is
+// needed here. It emits one log line carrying the run id so logs can be correlated.
+exports.handler = async function (_event, _context) {
+    console.log(JSON.stringify({ message: "hello from one-e2e", run_id: process.env.ONE_E2E_RUN_ID }));
+
+    return {
+        statusCode: 200,
+        body: "hello, world",
+    };
+};

--- a/e2e/fixture/src/package.json
+++ b/e2e/fixture/src/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "one-e2e-workload",
+  "version": "1.0.0",
+  "description": "Minimal hello-world Lambda workload for the lambda-datadog e2e suite.",
+  "main": "index.js",
+  "license": "Apache-2.0"
+}

--- a/e2e/fixture/variables.tf
+++ b/e2e/fixture/variables.tf
@@ -3,9 +3,8 @@ variable "region" {
   type        = string
 }
 
-# When true, the Lambda is defined through the lambda-datadog module (instrumented).
-# When false, the same workload is defined as a bare aws_lambda_function (uninstrumented).
-# The instrumentation mechanism under test plugs in exactly here, at APPLY/REMOVE.
+# When true, the workload is defined through the lambda-datadog module (APPLY). When
+# false, the module is removed and no function exists (REMOVE) -- the clean end-state.
 variable "instrumented" {
   description = "Whether to define the workload through the lambda-datadog module."
   type        = bool

--- a/e2e/fixture/variables.tf
+++ b/e2e/fixture/variables.tf
@@ -1,0 +1,70 @@
+variable "region" {
+  description = "AWS region to deploy the workload into."
+  type        = string
+}
+
+# When true, the Lambda is defined through the lambda-datadog module (instrumented).
+# When false, the same workload is defined as a bare aws_lambda_function (uninstrumented).
+# The instrumentation mechanism under test plugs in exactly here, at APPLY/REMOVE.
+variable "instrumented" {
+  description = "Whether to define the workload through the lambda-datadog module."
+  type        = bool
+}
+
+# Unique workload identity. Set atomically at creation as the resource name prefix
+# (one-e2e-<tool>-<platform>-<runid>) and as the stable DD_SERVICE across phases.
+variable "service_name" {
+  description = "Unique workload name (one-e2e-tflambda-lambda-<runid>)."
+  type        = string
+}
+
+# Unix timestamp captured by the test at creation time. AWS does not expose a usable
+# native creation time cross-account, so the sweeper relies on this freshness tag.
+variable "created_ts" {
+  description = "Unix timestamp recorded as the one_e2e_created freshness tag."
+  type        = string
+}
+
+variable "run_id" {
+  description = "Run id correlator, surfaced on ingested telemetry via DD_TAGS."
+  type        = string
+}
+
+variable "datadog_api_key_secret_arn" {
+  description = "ARN of the Secrets Manager secret holding the Datadog API key."
+  type        = string
+}
+
+variable "datadog_site" {
+  description = "Datadog site the extension ships telemetry to."
+  type        = string
+}
+
+variable "dd_env" {
+  description = "DD_ENV applied to the workload and asserted on telemetry."
+  type        = string
+  default     = "e2e"
+}
+
+variable "dd_version" {
+  description = "DD_VERSION applied to the workload and asserted on telemetry."
+  type        = string
+  default     = "1.0.0"
+}
+
+variable "runtime" {
+  description = "Canonical Node.js runtime for the workload."
+  type        = string
+  default     = "nodejs22.x"
+}
+
+# Pinned so a telemetry failure blames the module wiring, not a layer/extension drift.
+variable "datadog_extension_layer_version" {
+  description = "Pinned Datadog extension layer version."
+  type        = number
+}
+
+variable "datadog_node_layer_version" {
+  description = "Pinned Datadog Node layer version."
+  type        = number
+}

--- a/e2e/fixture/versions.tf
+++ b/e2e/fixture/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.77.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.4.0"
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Adds the Terraform fixture the e2e suite drives: an IAM role plus the workload Lambda defined through the `lambda-datadog` module, with an `instrumented` toggle. When on, the module creates the function (APPLY); when off, it's removed, leaving no function (REMOVE). Infra only -- the test that consumes it lands in the next PR.

The handler is a minimal hello-world that logs the run id; tracing and log collection are auto-injected by the Datadog layers and extension. Resources are run-uniquely named and tagged for the cross-repo sweeper.
